### PR TITLE
Display recent pages on home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,24 @@ layout: default
 
 The website is uncertain, measurement under process.
 
-# Recent Updates
+## Recent Updates
 
+{% assign recent_pages = site.pages | sort: 'date' | reverse %}
+{% assign recent_pages = recent_pages | where_exp: 'p', 'p.title and p.url != "/" and p.url != "/404.html"' %}
+<table class="updates-table">
+  <thead>
+    <tr>
+      <th>Page</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for page in recent_pages limit:5 %}
+    <tr>
+      <td><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a></td>
+      <td>{{ page.date | date: "%b %d, %Y" }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 
-# Feature Blogs

--- a/style.scss
+++ b/style.scss
@@ -162,6 +162,27 @@ p > img {
   margin: 0 auto;
 }
 
+table.updates-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 auto;
+}
+
+table.updates-table th,
+table.updates-table td {
+  padding: 0.5rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid $lightGray;
+}
+
+table.updates-table tr:last-child td {
+  border-bottom: none;
+}
+
+table.updates-table th {
+  color: $darkerGray;
+}
+
 // Fixes images in popup boxes from Google Translate
 .gmnoprint img {
   max-width: none;


### PR DESCRIPTION
## Summary
- Remove unused "Feature Blogs" section from landing page
- Add dynamic table listing 5 most recent pages and minimal table styling

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aeac77741c8331aedbda6ec836b48b